### PR TITLE
update clean-mqtt commandline order

### DIFF
--- a/components/mqtt.rst
+++ b/components/mqtt.rst
@@ -166,7 +166,7 @@ retained messages for you:
 
 .. code-block:: bash
 
-    esphome configuration.yaml clean-mqtt
+    esphome clean-mqtt configuration.yaml
 
 With Docker:
 


### PR DESCRIPTION
update clean-mqtt to current esphome commandline order

## Description:
The esphome commandline does not accept the documented command. This PR updates to current command line structure.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
